### PR TITLE
Fix disable jinja2 auto* for performance

### DIFF
--- a/doq/template.py
+++ b/doq/template.py
@@ -8,6 +8,8 @@ class Template:
     def __init__(self, paths):
         self.env = Environment(
             loader=FileSystemLoader(paths),
+            autoescape=False,
+            auto_reload=False,
         )
 
     def load(self, params, filename=None):


### PR DESCRIPTION
```
$ python -m doq.cli --recursive -d /path/to/werkzeug
```

Before
`5.95s user 0.22s system 95% cpu 6.467 total`
After
`5.23s user 0.15s system 96% cpu 5.584 total`