### PR TITLE
Do not fail if no input given

### DIFF
--- a/doq/cli.py
+++ b/doq/cli.py
@@ -176,7 +176,7 @@ def run(args):
 
     if not targets:
         return
-    
+
     for target in targets:
         docstrings = generate_docstrings(
             code=target['lines'],

--- a/doq/cli.py
+++ b/doq/cli.py
@@ -174,6 +174,9 @@ def run(args):
 
     omissions = args.omit.split(',') if args.omit else None
 
+    if not targets:
+        return
+    
     for target in targets:
         docstrings = generate_docstrings(
             code=target['lines'],


### PR DESCRIPTION
Running `doq` and pressing Ctrl-D produces a traceback. With this PR it just exits.