### PR TITLE
added handling and test for bare raise statements

### DIFF
--- a/doq/parser.py
+++ b/doq/parser.py
@@ -102,7 +102,7 @@ def parse_defs(module, omissions=None, ignore_exception=False, ignore_yield=Fals
             for e in d.iter_raise_stmts():
                 if hasattr(e, 'children'):
                     exceptions.append(e.children[1].get_first_leaf().get_code().strip())
-                else: # bare raise
+                else:  # bare raise
                     exceptions.append('')
 
         results.append(

--- a/doq/parser.py
+++ b/doq/parser.py
@@ -100,7 +100,10 @@ def parse_defs(module, omissions=None, ignore_exception=False, ignore_yield=Fals
         exceptions = []
         if ignore_exception is False:
             for e in d.iter_raise_stmts():
-                exceptions.append(e.children[1].get_first_leaf().get_code().strip())
+                if hasattr(e, 'children'):
+                    exceptions.append(e.children[1].get_first_leaf().get_code().strip())
+                else: # bare raise
+                    exceptions.append('')
 
         results.append(
             {

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -864,6 +864,7 @@ class ParseTestCase(TestCase):
             },
             actual,
         )
+
     def test_bare_raise(self):
         line = '\n'.join([
             'def foo():',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -864,6 +864,31 @@ class ParseTestCase(TestCase):
             },
             actual,
         )
+    def test_bare_raise(self):
+        line = '\n'.join([
+            'def foo():',
+            '   try:',
+            '      12/0',
+            '   except:',
+            '      raise',
+        ])
+
+        actual = parse(line)[0]
+        self.assertDictEqual(
+            {
+                'name': 'foo',
+                'params': [],
+                'return_type': None,
+                'start_lineno': 1,
+                'start_col': 0,
+                'end_lineno': 5,
+                'end_col': 11,
+                'is_doc_exists': False,
+                'exceptions': [''],
+                'yields': [],
+            },
+            actual,
+        )
 
 
 class ReturnTypeTestCase(TestCase):


### PR DESCRIPTION
Bare raise statements can be emitted from parso's `module.iter_raise_stmts` which is used in `parser.py` when appending exceptions. These statements will have no children (no variable name assigned to the exception). This PR suggests appending an empty string to signify an exception but without a variable name. 

closes #101 