### PR TITLE
completion

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_version.py
 ### https://raw.github.com/github/gitignore/85bf08b19a77c62d7b6286c2db8811f2ff373b0f/Python.gitignore
 
 # Byte-compiled / optimized / DLL files

--- a/README.rst
+++ b/README.rst
@@ -192,6 +192,12 @@ configuration file example::
   style = "json"
   template_path = "/path/to/template"
 
+Completion
+==========
+
+This program provides shell completions. It should be out of box if you install
+it from a wheel file.
+
 LICENSE
 =======
 

--- a/doq/__init__.py
+++ b/doq/__init__.py
@@ -6,4 +6,8 @@ from doq.config import find_config # noqa F401
 from doq.parser import parse   # noqa F401
 from doq.template import Template  # noqa F401
 
-__version__ = '0.9.1'
+# avoid bug when `pyproject-build`
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = ""

--- a/doq/_shtab.py
+++ b/doq/_shtab.py
@@ -1,0 +1,20 @@
+from argparse import Action
+
+FILE = DIR = {}
+
+
+class PrintCompletionAction(Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        print('Please install shtab firstly!')  # noqa: T001 print found
+        parser.exit(0)
+
+
+def add_argument_to(parser, *args, **kwargs):
+    Action.complete = None  # type: ignore
+    parser.add_argument(
+        '--print-completion',
+        choices=['bash', 'zsh', 'tcsh'],
+        action=PrintCompletionAction,
+        help='print shell completion script',
+    )
+    return parser

--- a/doq/cli.py
+++ b/doq/cli.py
@@ -250,13 +250,18 @@ def parse_options():
         description='Docstring generator.',
         add_help=True,
     )
+    try:
+        import shtab
+    except ImportError:
+        from . import _shtab as shtab
+    shtab.add_argument_to(parser)
     parser.add_argument(
         '-f',
         '--file',
         type=argparse.FileType('r'),
         default='-',
         help='File or STDIN',
-    )
+    ).complete = shtab.FILE
     parser.add_argument(
         '--start',
         type=int,
@@ -275,7 +280,7 @@ def parse_options():
         type=str,
         default=None,
         help='Path to template directory',
-    )
+    ).complete = shtab.DIR
     parser.add_argument(
         '-s',
         '--style',
@@ -312,7 +317,7 @@ def parse_options():
         '--directory',
         default='',
         help='Path to directory',
-    )
+    ).complete = shtab.DIR
     parser.add_argument(
         '-w',
         '--write',
@@ -331,7 +336,7 @@ def parse_options():
         '--config',
         default=None,
         help='Path to a setup.cfg or pyproject.toml',
-    )
+    ).complete = shtab.FILE
     parser.add_argument(
         '--ignore_exception',
         action='store_true',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["setuptools_scm", "setuptools-generate == 0.0.6", "parso"]
+build-backend = "setuptools.build_meta"
+
+# https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
+[project]
+name = "doq"
+description = "Docstring generator"
+readme = "README.rst"
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Environment :: Web Environment",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: BSD License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Topic :: Documentation",
+  "Topic :: Software Development :: Documentation",
+]
+dependencies = ["parso", "jinja2", "toml"]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+completion = ["shtab"]
+test = ["parameterized"]
+
+[[project.authors]]
+name = "Shinya Ohyanagi"
+email = "sohyanagi@gmail.com"
+
+[project.license]
+text = "BSD"
+
+[project.urls]
+Homepage = "http://github.com/heavenshell/py-doq"
+
+[project.scripts]
+doq = "doq.cli:main"
+
+[tool.setuptools.data-files]
+"share/man/man1" = ["sdist/doq.1"]
+"share/bash-completion/completions" = ["sdist/doq"]
+"share/zsh/site-functions" = ["sdist/_doq"]
+
+[tool.setuptools.packages.find]
+include = ["doq"]
+
+[tool.setuptools_scm]
+write_to = "doq/_version.py"

--- a/setup.py
+++ b/setup.py
@@ -1,54 +1,5 @@
-import os
+# https://github.com/heavenshell/py-doq/pull/125
+# make CI/CD happy
+from setuptools import setup
 
-from setuptools import (
-    find_packages,
-    setup,
-)
-
-version = ''
-with open('doq/__init__.py') as f:
-    for line in f.readlines():
-        if line.startswith('__version__'):
-            version = line.split('=')[1].strip().replace("'", '')
-
-rst_path = os.path.join(os.path.dirname(__file__), 'README.rst')
-description = ''
-with open(rst_path) as f:
-    description = f.read()
-
-setup(
-    name='doq',
-    version=version,
-    author='Shinya Ohyanagi',
-    author_email='sohyanagi@gmail.com',
-    url='http://github.com/heavenshell/py-doq',
-    description='Docstring generator',
-    long_description=description,
-    license='BSD',
-    platforms='any',
-    packages=find_packages(exclude=['tests']),
-    package_dir={'': '.'},
-    include_package_data=True,
-    package_data={'doq': [
-        'templates/google/*.txt',
-        'templates/numpy/*.txt',
-        'templates/sphinx/*.txt',
-    ]},
-    install_requires=['parso', 'jinja2', 'toml'],
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Topic :: Documentation',
-        'Topic :: Software Development :: Documentation',
-    ],
-    entry_points="""
-    [console_scripts]
-    doq = doq.cli:main
-    """,
-    tests_require=['parameterized'],
-    test_suite='tests',
-)
+setup()


### PR DESCRIPTION
- Add completion
- Support PEP621

Demo:

```sh
$ pip install build installer
$ git clone --branch=completion https://github.com/Freed-Wu/py-doq
$ cd py-doq
$ pyproject-build
$ python -m installer --prefix=/tmp/test dist/doq-0.9.2.dev1+g74db2e6.d20230718-py2.py3-none-any.whl
$ tree /tmp/test
 /tmp/test
├──  bin
│  └──  doq
├──  lib
│  └──  python3.11
│     └──  site-packages
│        ├──  doq
│        │  ├──  __init__.py
│        │  ├──  __pycache__
│        │  │  └── ...
│        │  ├──  _shtab.py
│        │  ├──  _version.py
│        │  ├── ...
│        │  └──  templates
│        │     └── ...
│        └──  doq-0.9.2.dev1+g74db2e6.d20230718.dist-info
│           ├──  entry_points.txt
│           ├──  LICENSE
│           ├──  METADATA
│           ├──  RECORD
│           ├──  top_level.txt
│           └──  WHEEL
└──  share
   ├──  bash-completion
   │  └──  completions
   │     └──  doq
   ├──  man
   │  └──  man1
   │     └──  doq.1
   └──  zsh
      └──  site-functions
         └──  _doq
# You get your bash/zsh completion scripts and man page.
$ PYTHONPATH=/tmp/test/lib/python3.11/site-packages /tmp/test/bin/doq --help
usage: doq [-h] [-f FILE] [--start START] [--end END] [-t TEMPLATE_PATH]
           [-s STYLE] [--formatter FORMATTER] [--indent INDENT] [--omit OMIT]
           [-r] [-d DIRECTORY] [-w] [-v] [-c CONFIG] [--ignore_exception]
           [--ignore_yield] [--ignore_init]

Docstring generator.

options:
  -h, --help            show this help message and exit
  --print-completion {bash,zsh,tcsh}
                        print shell completion script
...
```
