### PR TITLE
Fix stop use setuptools_scm for to manage versions manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-_version.py
 ### https://raw.github.com/github/gitignore/85bf08b19a77c62d7b6286c2db8811f2ff373b0f/Python.gitignore
 
 # Byte-compiled / optimized / DLL files

--- a/doq/__init__.py
+++ b/doq/__init__.py
@@ -6,8 +6,4 @@ from doq.config import find_config # noqa F401
 from doq.parser import parse   # noqa F401
 from doq.template import Template  # noqa F401
 
-# avoid bug when `pyproject-build`
-try:
-    from ._version import __version__
-except ImportError:
-    __version__ = ""
+__version__ = '0.9.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 completion = ["shtab"]
-test = ["parameterized"]
+test = ["parameterized", "pytest"]
 
 [[project.authors]]
 name = "Shinya Ohyanagi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools_scm", "setuptools-generate == 0.0.6", "parso"]
+requires = ["setuptools-generate == 0.0.6", "parso"]
 build-backend = "setuptools.build_meta"
 
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
@@ -45,8 +45,8 @@ doq = "doq.cli:main"
 [tool.setuptools.packages.find]
 include = ["doq"]
 
-[tool.setuptools_scm]
-write_to = "doq/_version.py"
+[tool.setuptools.dynamic]
+version = {attr = "doq.__version__"}
 
 [tool.pytest.ini_options]
 addopts = "-ra"


### PR DESCRIPTION
My workflow is...

- Create bump version Pull request
- Merge to main branch
- Add tag
- Create GitHub release by release-drafter
- Publish to PyPi
